### PR TITLE
 asterisk globbing inside the source Docker image and additional fixes

### DIFF
--- a/bin/strip-docker-image
+++ b/bin/strip-docker-image
@@ -113,7 +113,7 @@ DIR=strip-docker-image-$$
 mkdir -p $DIR/export
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-docker run -v $PWD/$DIR/export:/export \
+docker run --rm -v $PWD/$DIR/export:/export \
 	  -v $SCRIPT_DIR:/mybin $IMAGE_NAME \
 	  /mybin/strip-docker-image-export -d /export $VERBOSE $PACKAGES $FILES
 

--- a/bin/strip-docker-image
+++ b/bin/strip-docker-image
@@ -1,38 +1,38 @@
 #!/bin/bash
 # NAME
-#	strip-docker-image - strips the bare essentials from an image and exports them
+# strip-docker-image - strips the bare essentials from an image and exports them
 #
 # SYNOPSIS
-#	strip-docker-image -i image-name -t target-image-name -t [-p package | -f file] [-x expose-port] [-v] 
+# strip-docker-image -i image-name -t target-image-name -t [-p package | -f file] [-x expose-port] [-v] 
 #
 #
 # OPTIONS
-#	-i image-name		to strip
-#	-t target-image-name	the image name of the stripped image
-#	-p package		package to include from image, multiple -p allowed.
-#	-f file			file to include from image, multiple -f allowed.
-#	-x port			to expose.
-#	-v			verbose
+# -i image-name   to strip
+# -t target-image-name  the image name of the stripped image
+# -p package    package to include from image, multiple -p allowed.
+# -f file     file to include from image, multiple -f allowed.
+# -x port     to expose.
+# -v      verbose
 #
 # DESCRIPTION
-#   	creates a new Docker image based on the scratch  which contains
-#	only the the source image of selected packages and files.
+#     creates a new Docker image based on the scratch  which contains
+# only the the source image of selected packages and files.
 #
 # EXAMPLE
-#	The following example strips the nginx installation from the default NGiNX docker image,
+# The following example strips the nginx installation from the default NGiNX docker image,
 #
 #        strip-docker-image -i nginx -t stripped-nginx  \
-#			-p nginx  \
-#			-f /etc/passwd \
-#			-f /etc/group \
-#			-f '/lib/*/libnss*' \
-#			-f /bin/ls \
-#			-f /bin/cat \
-#			-f /bin/sh \
-#			-f /bin/mkdir \
-#			-f /bin/ps \
-#			-f /var/run \
-#			-f /var/log/nginx
+#     -p nginx  \
+#     -f /etc/passwd \
+#     -f /etc/group \
+#     -f /bin/ls \
+#     -f /bin/cat \
+#     -f /bin/sh \
+#     -f /bin/mkdir \
+#     -f /bin/ps \
+#     -f /var/run \
+#     -f /var/log/nginx \
+#     -f '/lib/*/libnss*' \
 #
 # AUTHOR
 #  Mark van Holsteijn
@@ -56,56 +56,61 @@
 #
 
 function usage() {
-	echo "usage: $(basename $0) -i image-name -t stripped-image-name [-p package | -f file] [-v]" >&2
-	echo "	$@" >&2
+  echo "usage: $(basename $0) -i image-name -t stripped-image-name [-p package | -f file] [-v]" >&2
+  echo "  $@" >&2
 }
 
 function parse_commandline() {
 
-	while getopts "vi:t:p:f:x:" OPT; do
-	    case "$OPT" in
-		v)
-		    VERBOSE=-v
-		    ;;
-		p)
-		    PACKAGES="$PACKAGES -p $OPTARG"
-		    ;;
-		f)
-		    FILES="$FILES -f $OPTARG"
-		    ;;
-		i)
-		    IMAGE_NAME="$OPTARG"
-		    ;;
-		t)
-		    TARGET_IMAGE_NAME="$OPTARG"
-		    ;;
-		x)
-		    EXPOSE_PORTS="$EXPOSE_PORTS $OPTARG"
-		    ;;
-		*)
-		    usage
-		    exit 1
-		    ;;
-	    esac
-	done
-	shift $((OPTIND-1))
+  while getopts "vi:t:p:f:x:" OPT; do
+      case "$OPT" in
+    v)
+        VERBOSE=-v
+        ;;
+    p)
+        PACKAGES="$PACKAGES -p $OPTARG"
+        ;;
+    f)
+        FILES+=" $(printf "${OPTARG}")"
+        ;;
+    i)
+        IMAGE_NAME="$OPTARG"
+        ;;
+    t)
+        TARGET_IMAGE_NAME="$OPTARG"
+        ;;
+    x)
+        EXPOSE_PORTS="$EXPOSE_PORTS $OPTARG"
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+      esac
+  done
+  shift $((OPTIND-1))
 
-	if [ -z "$IMAGE_NAME" ] ; then
-		usage "image name is missing."
-		exit 1
-	fi
+  if [ -z "$IMAGE_NAME" ] ; then
+    usage "image name is missing."
+    exit 1
+  fi
 
-	if [ -z "$TARGET_IMAGE_NAME" ] ; then
-		usage "target image name -t missing."
-		exit 1
-	fi
+  if [ -z "$TARGET_IMAGE_NAME" ] ; then
+    usage "target image name -t missing."
+    exit 1
+  fi
 
-	if [ -z "$PACKAGES" -a -z "$FILES" ] ; then
-		usage "Missing -p or -f options"
-		exit 1
-	fi
-	export PACKAGES FILES VERBOSE
+  if [ -z "$PACKAGES" -a -z "$FILES" ] ; then
+    usage "Missing -p or -f options"
+    exit 1
+  fi
+  export PACKAGES FILES VERBOSE
 }
+
+if [ $UID != 0 ] ; then
+  echo 'Doing serious stuff here, must be root to perform this action.' >&2
+  exit 1
+fi
 
 parse_commandline "$@"
 
@@ -114,8 +119,8 @@ mkdir -p $DIR/export
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 docker run --rm -v $PWD/$DIR/export:/export \
-	  -v $SCRIPT_DIR:/mybin $IMAGE_NAME \
-	  /mybin/strip-docker-image-export -d /export "${VERBOSE} ${PACKAGES} ${FILES}"
+    -v $SCRIPT_DIR:/mybin $IMAGE_NAME \
+    /mybin/strip-docker-image-export -d /export "${VERBOSE} ${PACKAGES} $(for f in ${FILES}; do echo -n " -f $f";done )"
 
 cat > $DIR/Dockerfile <<!
 FROM scratch
@@ -123,12 +128,10 @@ ADD export /
 !
 
 for PORT in $EXPOSE_PORTS ; do
-	echo EXPOSE $PORT >> $DIR/Dockerfile
+  echo EXPOSE $PORT >> $DIR/Dockerfile
 done
 
-(
-	cd $DIR
-	docker build --no-cache -t $TARGET_IMAGE_NAME .
-)
+cd $DIR
+docker build --no-cache -t $TARGET_IMAGE_NAME .
 
 rm -rf $DIR

--- a/bin/strip-docker-image
+++ b/bin/strip-docker-image
@@ -4,7 +4,7 @@
 #
 # SYNOPSIS
 #	strip-docker-image -i image-name -t target-image-name -t [-p package | -f file] [-x expose-port] [-v] 
-#			
+#
 #
 # OPTIONS
 #	-i image-name		to strip
@@ -32,10 +32,10 @@
 #			-f /bin/mkdir \
 #			-f /bin/ps \
 #			-f /var/run \
-#			-f /var/log/nginx 
+#			-f /var/log/nginx
 #
 # AUTHOR
-#  Mark van Holsteijn 
+#  Mark van Holsteijn
 #
 # COPYRIGHT
 #
@@ -115,7 +115,7 @@ SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 docker run --rm -v $PWD/$DIR/export:/export \
 	  -v $SCRIPT_DIR:/mybin $IMAGE_NAME \
-	  /mybin/strip-docker-image-export -d /export $VERBOSE $PACKAGES $FILES
+	  /mybin/strip-docker-image-export -d /export "${VERBOSE} ${PACKAGES} ${FILES}"
 
 cat > $DIR/Dockerfile <<!
 FROM scratch

--- a/bin/strip-docker-image-export
+++ b/bin/strip-docker-image-export
@@ -1,44 +1,44 @@
 #!/bin/bash
-
+#set -x
 # NAME
-#	strip-docker-image-export  - exports the bare essentials from a Docker image
+# strip-docker-image-export  - exports the bare essentials from a Docker image
 #
 # SYNOPSIS
-#	strip-docker-image-export  [-d export-dir ] [-p package | -f file] [-v]
+# strip-docker-image-export  [-d export-dir ] [-p package | -f file] [-v]
 #
 #
 # OPTIONS
-#	-d export-directory	to copy content to, defaults to /export.
-#	-p package		package to include from image, multiple -p allowed.
-#	-f file			file to include from image, multiple -f allowed.
-#	-v			verbose
+# -d export-directory to copy content to, defaults to /export.
+# -p package    package to include from image, multiple -p allowed.
+# -f file     file to include from image, multiple -f allowed.
+# -v      verbose
 #
 # DESCRIPTION
-#   	this script copies all the files from an installed package and copies them
-#	to an export directory. Additional files can be added. When an executable
-#	is copied, all dynamic libraries required by the executed are included too.
+#     this script copies all the files from an installed package and copies them
+# to an export directory. Additional files can be added. When an executable
+# is copied, all dynamic libraries required by the executed are included too.
 #
 # EXAMPLE
-#	The following example strips the nginx installation from the default NGiNX docker image, 
-#	and allows the files in ./export to be added to a scratch image.
+# The following example strips the nginx installation from the default NGiNX docker image, 
+# and allows the files in ./export to be added to a scratch image.
 #
 #        docker run -v $PWD/export/:/export \
-#		   -v $PWD/bin:/mybin nginx \
-#		/mybin/strip-image.sh \
-#			-p nginx  \
-#			-f /etc/passwd \
-#			-f /etc/group \
-#			-f '/lib/*/libnss*' \
-#			-f /bin/ls \
-#			-f /bin/cat \
-#			-f /bin/sh \
-#			-f /bin/mkdir \
-#			-f /bin/ps \
-#			-f /var/run \
-#			-f /var/log/nginx \
-#			-d /export
+#      -v $PWD/bin:/mybin nginx \
+#   /mybin/strip-image.sh \
+#     -p nginx  \
+#     -f /etc/passwd \
+#     -f /etc/group \
+#     -f '/lib/*/libnss*' \
+#     -f /bin/ls \
+#     -f /bin/cat \
+#     -f /bin/sh \
+#     -f /bin/mkdir \
+#     -f /bin/ps \
+#     -f /var/run \
+#     -f /var/log/nginx \
+#     -d /export
 # CAVEATS
-#	requires an image that has a bash, readlink and ldd  installed.
+# requires an image that has a bash, readlink and ldd  installed.
 #
 # AUTHOR
 #  Mark van Holsteijn
@@ -62,102 +62,102 @@
 export EXPORT_DIR=/export
 
 function usage() {
-	echo "usage: $(basename $0) [-v] [-d export-dir ] [-p package | -f file]" >&2
-	echo "	$@" >&2
+  echo "usage: $(basename $0) [-v] [-d export-dir ] [-p package | -f file]" >&2
+  echo "  $@" >&2
 }
 
 function parse_commandline() {
 
-	while getopts "vp:f:d:" OPT; do
-	    case "$OPT" in
-		v)
-		    VERBOSE=v
-		    ;;
-		p)
-		    PACKAGES="$PACKAGES $OPTARG"
-		    ;;
-		f)
-		    FILES="$FILES $OPTARG"
-		    ;;
-		d)
-		    EXPORT_DIR="$OPTARG"
-		    ;;
-		*)
-		    usage
-		    exit 1
-		    ;;
-	    esac
-	done
-	shift $((OPTIND-1))
+  while getopts "vp:f:d:" OPT; do
+      case "$OPT" in
+    v)
+        VERBOSE=v
+        ;;
+    p)
+        PACKAGES="$PACKAGES $OPTARG"
+        ;;
+    f)
+        FILES="$FILES $(printf "${OPTARG}")"
+        ;;
+    d)
+        EXPORT_DIR="$OPTARG"
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+      esac
+  done
+  shift $((OPTIND-1))
 
-	if [ -z "$PACKAGES" -a -z "$FILES" ] ; then
-		usage "Missing -p or -f options"
-		exit 1
-	fi
-	if [ ! -d $EXPORT_DIR ] ; then
-		usage "$EXPORT_DIR is not a directory."
-		exit 1
-	fi
+  if [ -z "$PACKAGES" -a -z "$FILES" ] ; then
+    usage "Missing -p or -f options"
+    exit 1
+  fi
+  if [ ! -d $EXPORT_DIR ] ; then
+    usage "$EXPORT_DIR is not a directory."
+    exit 1
+  fi
 }
 
 function print_file() {
-		if [ -e "$1" ] ; then
-			test -n "$VERBOSE" && echo "INFO: analysing file file '$1'" >&2
-			if grep -Fxq "$1" $EXPORT_DIR/file_list
-			then
-				echo "$1" > /dev/null
-				test -n "$VERBOSE" && echo "INFO: ignoring already exists file '$1'" >&2
-			else
-				echo "$1"
-				echo "$1" >> $EXPORT_DIR/file_list
-				test -n "$VERBOSE" && echo "INFO: adding file '$1'" >&2
-			fi
-		else
-			test -n "$VERBOSE" && echo "INFO: ignoring not existent file '$1'" >&2
-		fi
+    if [ -e "$1" ] ; then
+      test -n "$VERBOSE" && echo "INFO: analysing file file '$1'" >&2
+      if grep -Fxq "$1" $EXPORT_DIR/file_list
+      then
+        echo "$1" > /dev/null
+        test -n "$VERBOSE" && echo "INFO: ignoring already exists file '$1'" >&2
+      else
+        echo "$1"
+        echo "$1" >> $EXPORT_DIR/file_list
+        test -n "$VERBOSE" && echo "INFO: adding file '$1'" >&2
+      fi
+    else
+      test -n "$VERBOSE" && echo "INFO: ignoring not existent file '$1'" >&2
+    fi
 
-		if [ -s "$1" ] ; then
-			TARGET=$(readlink "$1")
-			if  [ -n "$TARGET" ] ; then
-				if expr "$TARGET" : '^/' >/dev/null 2>&1 ; then
-					list_dependencies "$TARGET"
-				else
-					list_dependencies $(dirname "$1")/"$TARGET"
-				fi
-			fi
-		fi
+    if [ -s "$1" ] ; then
+      TARGET=$(readlink "$1")
+      if  [ -n "$TARGET" ] ; then
+        if expr "$TARGET" : '^/' >/dev/null 2>&1 ; then
+          list_dependencies "$TARGET"
+        else
+          list_dependencies $(dirname "$1")/"$TARGET"
+        fi
+      fi
+    fi
 }
 
 function list_dependencies() {
-	for FILE in $@ ; do
-		if [ -e "$FILE" ] ; then
-			print_file "$FILE"
-			if /usr/bin/ldd "$FILE" >/dev/null 2>&1 ; then
-				/usr/bin/ldd "$FILE" | \
-				awk '/statically/{next;} /=>/ { print $3; next; } { print $1 }' | \
-				while read LINE ; do
-					test -n "$VERBOSE" && echo "INFO: including $LINE" >&2
-					print_file "$LINE"
-				done
-			fi
-		else
-			test -n "$VERBOSE" && echo "INFO: ignoring not existent file $FILE" >&2
-		fi
-	done
+  for FILE in $@ ; do
+    if [ -e "$FILE" ] ; then
+      print_file "$FILE"
+      if /usr/bin/ldd "$FILE" >/dev/null 2>&1 ; then
+        /usr/bin/ldd "$FILE" | \
+        awk '/statically/{next;} /=>/ { print $3; next; } { print $1 }' | \
+        while read LINE ; do
+          test -n "$VERBOSE" && echo "INFO: including $LINE" >&2
+          print_file "$LINE"
+        done
+      fi
+    else
+      test -n "$VERBOSE" && echo "INFO: ignoring not existent file $FILE" >&2
+    fi
+  done
 }
 
 function list_packages() {
         /usr/bin/dpkg -L $1 | while read FILE ; do
-		if [ ! -d "$FILE" ] ; then
-			list_dependencies "$FILE"
-		fi
+    if [ ! -d "$FILE" ] ; then
+      list_dependencies "$FILE"
+    fi
         done
 }
 
 function list_all_packages() {
-	for i in "$@" ; do
-		list_packages "$i"
-	done
+  for i in "$@" ; do
+    list_packages "$i"
+  done
 }
 
 parse_commandline $@
@@ -166,10 +166,10 @@ cp -f /dev/null $EXPORT_DIR/file_list
 
 tar czf - $(
 
-	(
-	list_all_packages $PACKAGES
-	list_dependencies $FILES
-	)  | sort -u | uniq
+  (
+  list_all_packages $PACKAGES
+  list_dependencies $FILES
+  )  | sort -u | uniq
 
 ) | ( cd $EXPORT_DIR ; tar -xzh${VERBOSE}f - )
 

--- a/bin/strip-docker-image-export
+++ b/bin/strip-docker-image-export
@@ -4,8 +4,8 @@
 #	strip-docker-image-export  - exports the bare essentials from a Docker image
 #
 # SYNOPSIS
-#	strip-docker-image-export  [-d export-dir ] [-p package | -f file] [-v] 
-#			
+#	strip-docker-image-export  [-d export-dir ] [-p package | -f file] [-v]
+#
 #
 # OPTIONS
 #	-d export-directory	to copy content to, defaults to /export.
@@ -39,9 +39,9 @@
 #			-d /export
 # CAVEATS
 #	requires an image that has a bash, readlink and ldd  installed.
-# 
+#
 # AUTHOR
-#  Mark van Holsteijn 
+#  Mark van Holsteijn
 #
 # COPYRIGHT
 #
@@ -145,13 +145,13 @@ function list_packages() {
         done
 }
 
-function list_all_packages() {	
+function list_all_packages() {
 	for i in "$@" ; do
 		list_packages "$i"
-	done 
+	done
 }
 
-parse_commandline "$@"
+parse_commandline $@
 
 
 tar czf - $(

--- a/bin/strip-docker-image-export
+++ b/bin/strip-docker-image-export
@@ -102,7 +102,16 @@ function parse_commandline() {
 
 function print_file() {
 		if [ -e "$1" ] ; then
-			echo "$1"
+			test -n "$VERBOSE" && echo "INFO: analysing file file '$1'" >&2
+			if grep -Fxq "$1" $EXPORT_DIR/file_list
+			then
+				echo "$1" > /dev/null
+				test -n "$VERBOSE" && echo "INFO: ignoring already exists file '$1'" >&2
+			else
+				echo "$1"
+				echo "$1" >> $EXPORT_DIR/file_list
+				test -n "$VERBOSE" && echo "INFO: adding file '$1'" >&2
+			fi
 		else
 			test -n "$VERBOSE" && echo "INFO: ignoring not existent file '$1'" >&2
 		fi
@@ -153,13 +162,14 @@ function list_all_packages() {
 
 parse_commandline $@
 
+cp -f /dev/null $EXPORT_DIR/file_list
 
 tar czf - $(
 
 	(
 	list_all_packages $PACKAGES
 	list_dependencies $FILES
-	)  | sort -u
+	)  | sort -u | uniq
 
 ) | ( cd $EXPORT_DIR ; tar -xzh${VERBOSE}f - )
 

--- a/examples/strip-nginx
+++ b/examples/strip-nginx
@@ -1,16 +1,16 @@
 #!/bin/bash
 ../bin/strip-docker-image -i nginx -t stripped-nginx  \
-	       -x 80 \
-	       -p nginx  \
-	       -f /etc/passwd \
-	       -f /etc/group \
-	       -f '/lib/*/libnss*' \
-	       -f /bin/ls \
-	       -f /bin/cat \
-	       -f /bin/sh \
-	       -f /bin/mkdir \
-	       -f /bin/ps \
-	       -f /var/run \
-	       -f /var/log/nginx \
-	       -f /var/cache/nginx
-
+  -v \
+  -p nginx \
+  -f /etc/passwd \
+  -f /etc/group \
+  -f /etc/nsswitch.conf \
+  -f /bin/ls \
+  -f /bin/cat \
+  -f /bin/sh \
+  -f /bin/mkdir \
+  -f /bin/ps \
+  -f /var/run \
+  -f /var/log/nginx \
+  -f /var/cache/nginx \
+  -f '/lib/*/libnss*'


### PR DESCRIPTION
Main fix here is `Fix: asterisk globbing inside the source Docker image` cause if you pass `-f '/lib/*/libnss*'` the globing was made on the host system, not inside the source container.
