### PR TITLE
Added support for rpm-based systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 This utilities strips everything you do not need from an image and create a new image with just the bare necessities.
 
 ## Synopsis
-	strip-docker-image 	-i image-name 
-						-t target-image-name 
+	strip-docker-image 	-i image-name
+						-t target-image-name
 						[-p package]
 						[-f file]
-						[-x expose-port] 
-						[-v] 
-			
+						[-x expose-port]
+						[-v]
+
 ## Options
 	-i image-name			to strip
 	-t target-image-name	the image name of the stripped image
@@ -45,7 +45,7 @@ strip-docker-image -i nginx -t stripped-nginx  \
 						   -f /var/log/nginx \
 						   -f /var/cache/nginx
 ```
-Aside from the nginx package, I have added the files /etc/passwd, /etc/group and /lib/*/libnss* shared libraries 
+Aside from the nginx package, I have added the files /etc/passwd, /etc/group and /lib/*/libnss* shared libraries
 are necessary for getpwnam() to work correctly.
 
 The directories /var/run, /var/log/nginx and /var/cache/nginx are required for NGiNX to operate.
@@ -71,4 +71,6 @@ docker run --link nginx:stripped cargonauts/toolbox-networking curl -s -D - http
 ```
 
 ## Caveats
-This utility requires bash, dpkg, tar, readlink and ldd to be installed in the container.
+This utility requires bash, tar, readlink, ldd, and either dpkg or rpm to be installed in the container.
+
+Note that on systems with rpm, you must specify full package names when using the -p switch, e.g. ```-p nginx-1.8.0-1.el7.ngx.x86_64```

--- a/bin/strip-docker-image-export
+++ b/bin/strip-docker-image-export
@@ -4,8 +4,8 @@
 #	strip-docker-image-export  - exports the bare essentials from a Docker image
 #
 # SYNOPSIS
-#	strip-docker-image-export  [-d export-dir ] [-p package | -f file] [-v] 
-#			
+#	strip-docker-image-export  [-d export-dir ] [-p package | -f file] [-v]
+#
 #
 # OPTIONS
 #	-d export-directory	to copy content to, defaults to /export.
@@ -19,7 +19,7 @@
 #	is copied, all dynamic libraries required by the executed are included too.
 #
 # EXAMPLE
-#	The following example strips the nginx installation from the default NGiNX docker image, 
+#	The following example strips the nginx installation from the default NGiNX docker image,
 #	and allows the files in ./export to be added to a scratch image.
 #
 #        docker run -v $PWD/export/:/export \
@@ -39,9 +39,9 @@
 #			-d /export
 # CAVEATS
 #	requires an image that has a bash, readlink and ldd  installed.
-# 
+#
 # AUTHOR
-#  Mark van Holsteijn 
+#  Mark van Holsteijn
 #
 # COPYRIGHT
 #
@@ -138,17 +138,22 @@ function list_dependencies() {
 }
 
 function list_packages() {
-        /usr/bin/dpkg -L $1 | while read FILE ; do
-		if [ ! -d "$FILE" ] ; then
-			list_dependencies "$FILE"
+		if command -v /usr/bin/dpkg -L $1 >/dev/null 2>&1; then
+			DEPS=$(/usr/bin/dpkg -L $1)
+		else
+			DEPS=$(/usr/bin/rpm -ql $1)
 		fi
-        done
+		cat "$DEPS" | while read FILE ; do
+			if [ ! -d "$FILE" ] ; then
+				list_dependencies "$FILE"
+			fi
+    done
 }
 
-function list_all_packages() {	
+function list_all_packages() {
 	for i in "$@" ; do
 		list_packages "$i"
-	done 
+	done
 }
 
 parse_commandline "$@"
@@ -162,4 +167,3 @@ tar czf - $(
 	)  | sort -u
 
 ) | ( cd $EXPORT_DIR ; tar -xzh${VERBOSE}f - )
-

--- a/bin/strip-docker-image-export
+++ b/bin/strip-docker-image-export
@@ -143,11 +143,11 @@ function list_packages() {
 		else
 			DEPS=$(/usr/bin/rpm -ql $1)
 		fi
-		cat "$DEPS" | while read FILE ; do
+		while read FILE ; do
 			if [ ! -d "$FILE" ] ; then
 				list_dependencies "$FILE"
 			fi
-    done
+    done <<< "$DEPS"
 }
 
 function list_all_packages() {


### PR DESCRIPTION
The use of dpkg limits which kinds of systems can be used to shrink an image.  I added a test to automatically choose `dpkg -L` or `rpm -ql` in `strip-docker-image-export:list_packages()` depending on the existence of /usr/bin/dpkg.  I also updated the documentation to reflect support for rpm.

Note that on an rpm-based system, the -p switch requires full package names (e.g. `-p nginx-1.8.0-1.el7.ngx.x86_64`).  This is noted in the README as well.
