### PR TITLE
Set entrypoint for image to /bin/bash

### DIFF
--- a/bin/strip-docker-image
+++ b/bin/strip-docker-image
@@ -114,7 +114,9 @@ mkdir -p $DIR/export
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 docker run -v $PWD/$DIR/export:/export \
-	  -v $SCRIPT_DIR:/mybin $IMAGE_NAME \
+	  -v $SCRIPT_DIR:/mybin \
+	  --entrypoint="/bin/bash" \
+	  $IMAGE_NAME \
 	  /mybin/strip-docker-image-export -d /export $VERBOSE $PACKAGES $FILES
 
 cat > $DIR/Dockerfile <<!


### PR DESCRIPTION
Images with an `ENTRYPOINT` in their Dockerfile will not run the export script. As it is written in bash, adding `--entrypoint="/bin/bash"` to the `docker run` command fixes this issue, and works for images without an `ENTRYPOINT` specified too (assuming bash is installed, which is required to run the export script anyway).
