### PR TITLE
Transfer ports, cmd and entrypoint from source image

### DIFF
--- a/bin/strip-docker-image
+++ b/bin/strip-docker-image
@@ -128,6 +128,14 @@ for PORT in $EXPOSE_PORTS ; do
 	echo EXPOSE $PORT >> $DIR/Dockerfile
 done
 
+EXPOSE=$(docker inspect -f '{{range $key, $value := .Config.ExposedPorts}}{{$key}} {{end}}' $IMAGE_NAME | sed -e 's/\/[a-z]* / /g')
+ENTRYPOINT=$(docker inspect --format='{{if .Config.Entrypoint}}ENTRYPOINT {{json .Config.Entrypoint}}{{end}}' $IMAGE_NAME)
+CMD=$(docker inspect --format='{{if .Config.Cmd}}CMD {{json .Config.Cmd}}{{end}}' $IMAGE_NAME)
+
+[ -z "$EXPOSE" ] || echo "EXPOSE $EXPOSE" >> $DIR/Dockerfile
+[ -z "$ENTRYPOINT" ] || echo $ENTRYPOINT >> $DIR/Dockerfile
+[ -z "$CMD" ] || echo $CMD >> $DIR/Dockerfile
+
 (
 	cd $DIR
 	docker build --no-cache -t $TARGET_IMAGE_NAME .


### PR DESCRIPTION
Simple addition to transfer any exposed ports and the CMD and ENTRYPOINT lines from the original Dockerfile.
