### PR TITLE
Add Alpine support

### DIFF
--- a/bin/strip-docker-image-export
+++ b/bin/strip-docker-image-export
@@ -101,6 +101,10 @@ function parse_commandline() {
 }
 
 function print_file() {
+		if [ "$1" = "/usr/bin/ldd" ]; then
+			exit
+		fi
+
 		if [ -e "$1" ] ; then
 			echo "$1"
 		else
@@ -138,10 +142,15 @@ function list_dependencies() {
 }
 
 function list_packages() {
-		if command -v /usr/bin/dpkg -L $1 >/dev/null 2>&1; then
+		if test -e /usr/bin/dpkg; then
 			DEPS=$(/usr/bin/dpkg -L $1)
-		else
+		elif test -e /usr/bin/rpm; then
 			DEPS=$(/usr/bin/rpm -ql $1)
+		elif test -e /sbin/apk; then
+			DEPS=$(/sbin/apk info -L $1 | grep -Ev '^$|contains:' | sed 's/^/\//g')
+		else
+			echo 'WARN: Unknown OS, aborted list_packages()'
+			exit
 		fi
 		while read FILE ; do
 			if [ ! -d "$FILE" ] ; then


### PR DESCRIPTION
I tested this with custom nodejs app and it works fine, but my code obviously needs to be improved.

There was infinite loop due to this, so I decided to hardcode skipping of `ldd`:

```
# readlink /usr/bin/ldd
/lib/ld-musl-x86_64.so.1

# /usr/bin/ldd /lib/ld-musl-x86_64.so.1 
	/usr/bin/ldd (0x7f1399ce5000)
```

Another issue is ability to list alpine package files. Not sure if it's enough to just check for executable.

Looking forward for your review.